### PR TITLE
fix: CI失敗を修正 - JUnit依存関係とE2Eテスト設定の修正

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,10 @@ val integrationTestImplementation by configurations.getting {
     extendsFrom(configurations.implementation.get())
     extendsFrom(configurations.testImplementation.get())
 }
-val endToEndTestImplementation by configurations
+val endToEndTestImplementation by configurations.getting {
+    extendsFrom(configurations.implementation.get())
+    extendsFrom(configurations.testImplementation.get())
+}
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -35,6 +38,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.34")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     integrationTestImplementation ("com.intuit.karate:karate-junit5:1.4.1")
     endToEndTestImplementation ("com.intuit.karate:karate-junit5:1.4.1")
 }

--- a/src/endToEndTest/java/com/github/miyashy/karatesample/controller/RunAllTest.java
+++ b/src/endToEndTest/java/com/github/miyashy/karatesample/controller/RunAllTest.java
@@ -14,7 +14,7 @@ public class RunAllTest {
     @Tag("all")
     @Test
     void runAllTest() {
-        Results results = Runner.path("classpass:").tags("~@ignore").parallel(1);
+        Results results = Runner.path("classpath:").tags("~@ignore").parallel(1);
         Assertions.assertEquals(0, results.getFailCount());
     }
 }

--- a/src/integrationTest/java/com/github/miyashy/karatesample/controller/TodoControllerTest.java
+++ b/src/integrationTest/java/com/github/miyashy/karatesample/controller/TodoControllerTest.java
@@ -1,12 +1,9 @@
 package com.github.miyashy.karatesample.controller;
 
 import com.intuit.karate.junit5.Karate;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class TodoControllerTest {
     @LocalServerPort

--- a/src/integrationTest/java/com/github/miyashy/karatesample/controller/UserControllerTest.java
+++ b/src/integrationTest/java/com/github/miyashy/karatesample/controller/UserControllerTest.java
@@ -1,12 +1,9 @@
 package com.github.miyashy.karatesample.controller;
 
 import com.intuit.karate.junit5.Karate;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class UserControllerTest {
     @LocalServerPort


### PR DESCRIPTION
## 概要
Spring Boot 3.5.3へのアップグレード後にCIが失敗していた問題を修正しました。

## 問題の原因
1. **JUnit Platform Launcherの欠落**: Spring Boot 3.5.3ではJUnit 5.12.2が使用されるようになり、JUnit 5.10以降では`junit-platform-launcher`を明示的に依存関係に追加する必要がある
2. **E2Eテスト設定の不備**: `endToEndTestImplementation`が`testImplementation`を継承していなかったため、必要な依存関係が不足していた
3. **Typo**: `RunAllTest.java`で`classpath:`が`classpass:`と誤記されていたため、E2Eテストのfeatureファイルが見つからなかった

## 修正内容
### build.gradle.kts
- `junit-platform-launcher`を`testRuntimeOnly`に追加
- `endToEndTestImplementation`が`testImplementation`を継承するよう設定を修正

### RunAllTest.java
- Typo修正: `classpass:` → `classpath:`

### 統合テストファイル
- Spring Boot 3対応のパッケージ名とアノテーションに更新
  - `@ExtendWith(SpringExtension.class)`を削除(Spring Boot 3では不要)
  - `org.springframework.boot.web.server.LocalServerPort` → `org.springframework.boot.test.web.server.LocalServerPort`

## 動作確認
- ✅ 統合テスト (`./gradlew integrationTest`): 5シナリオすべてパス
- ✅ E2Eテスト (`./gradlew parallelEndToEndTest`): 5シナリオすべてパス

## テスト計画
CIで以下のテストが実行され、成功することを確認:
- [ ] integrationTest
- [ ] endToEndTest (bootRun起動後)

🤖 Generated with [Claude Code](https://claude.com/claude-code)