### PR TITLE
chore: Spring Boot 3.5.3から4.0.1へアップグレード

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id 'org.springframework.boot' version '3.5.3'
-    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.springframework.boot' version '4.0.1'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
 }
 
@@ -28,6 +28,15 @@ configurations {
     integrationTestRuntimeOnly.extendsFrom runtimeOnly, testRuntimeOnly
     endToEndTestImplementation.extendsFrom implementation, testImplementation
     endToEndTestRuntimeOnly.extendsFrom runtimeOnly, testRuntimeOnly
+
+    // E2EテストではKarate互換性のためJUnit 5.xを固定
+    endToEndTestImplementation {
+        resolutionStrategy {
+            force 'org.junit.jupiter:junit-jupiter-api:5.12.2'
+            force 'org.junit.jupiter:junit-jupiter-engine:5.12.2'
+            force 'org.junit.platform:junit-platform-launcher:1.12.2'
+        }
+    }
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 概要
Spring Boot 3.5.3から4.0.1へのメジャーアップグレードを実施しました。

## 主な変更

### バージョン更新
- **Spring Boot**: 3.5.3 → 4.0.1
- **Gradle**: 8.8 → 8.14
- **dependency-management**: 1.1.4 → 1.1.7

### 依存関係の自動更新
Spring Boot 4.0により以下が自動的に更新されます：
- Spring Framework: 6.x → 7.0
- Jakarta EE: 10 → 11
- Servlet API: 6.0 → 6.1
- Tomcat: 10.x → 11.0.15
- JUnit Platform: 5.x → 6.x

## JUnit対応戦略

### テスト種別ごとのJUnitバージョン
| テスト種別 | JUnitバージョン | 対応方法 |
|-----------|----------------|---------|
| Unit Test | 6.x | Spring Boot 4に自動追従 |
| Integration Test | 6.x | Spring Boot 4に自動追従 |
| E2E Test (Karate) | 5.12.2 | バージョン固定 |

### E2Eテストの対応
Karate 1.4.1はJUnit 6未対応のため、E2Eテスト用の依存関係にのみJUnit 5.12.2を明示的に固定：

```groovy
configurations {
    endToEndTestImplementation {
        resolutionStrategy {
            force 'org.junit.jupiter:junit-jupiter-api:5.12.2'
            force 'org.junit.jupiter:junit-jupiter-engine:5.12.2'
            force 'org.junit.platform:junit-platform-launcher:1.12.2'
        }
    }
}
```

## 動作確認結果

### ローカル環境
- ✅ **ビルド**: 成功
- ✅ **統合テスト**: 成功（5シナリオすべてパス、JUnit 6使用）
- ✅ **E2Eテスト**: 成功（5シナリオすべてパス、JUnit 5使用）
- ✅ **アプリケーション起動**: 正常（Tomcat 11.0.15）

### CI確認予定
- [ ] integrationTest
- [ ] endToEndTest

## 備考
- springdoc-openapiは現状のバージョンのまま動作確認
- ソースコードの変更は不要（破壊的変更の影響なし）
- 既存の機能はすべて正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)